### PR TITLE
Issue #69 - Show exit confirmation modal when user clicks outside of the word category modal

### DIFF
--- a/app/static/js/drawing.js
+++ b/app/static/js/drawing.js
@@ -2,6 +2,7 @@ import { CountdownTimer } from './timer.js'
 
 let isWordCatModalVisible = false;
 let wordCatModal;
+let confirmModal;
 
 // Fetch a random word from the chosen category
 function fetchWord(category) {
@@ -21,6 +22,8 @@ function fetchWord(category) {
 // Display modal to select the category of word to draw when window loads
 window.addEventListener('load', () => {
     wordCatModal = new bootstrap.Modal('#word-category-modal');
+    confirmModal = new bootstrap.Modal(document.getElementById('confirm-modal'));
+
     wordCatModal.show();
     isWordCatModalVisible = true;
 
@@ -30,6 +33,12 @@ window.addEventListener('load', () => {
             fetchWord(category);
             isWordCatModalVisible = false;
         });
+    });
+
+    document.getElementById('word-category-modal').addEventListener('hidden.bs.modal', () => {
+        if (isWordCatModalVisible) {
+            confirmModal.show();
+        }
     });
 });
 


### PR DESCRIPTION
## Change Summary
1. Previously, if the user clicks on any area outside of the word category modal, it would close the modal and not start the timer or display a random word to draw. Changed the behaviour so that the exit confirmation modal shows instead.

## Change Form
- [x] The pull request title includes issue number and description.
- [x] The work done is summarised above.
- [x] The code is commented and well formatted.
- [x] Testing has been performed and documented above.

## Other Information
- Closes #69 